### PR TITLE
Use database connection of Porpoise::KeyValueObject when cleaning expired cache items

### DIFF
--- a/gemfiles/rails_3.gemfile.lock
+++ b/gemfiles/rails_3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    porpoise (0.9.4)
+    porpoise (0.9.7)
       activerecord (>= 3.2)
       activesupport (>= 3.2)
       rails (>= 3.2)

--- a/gemfiles/rails_4.gemfile.lock
+++ b/gemfiles/rails_4.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    porpoise (0.9.4)
+    porpoise (0.9.7)
       activerecord (>= 3.2)
       activesupport (>= 3.2)
       rails (>= 3.2)

--- a/gemfiles/rails_5.gemfile.lock
+++ b/gemfiles/rails_5.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    porpoise (0.9.4)
+    porpoise (0.9.7)
       activerecord (>= 3.2)
       activesupport (>= 3.2)
       rails (>= 3.2)

--- a/lib/active_support/cache/porpoise_store.rb
+++ b/lib/active_support/cache/porpoise_store.rb
@@ -27,7 +27,7 @@ module ActiveSupport
 
           deleted_items_count = 1
           while deleted_items_count > 0 do
-            deleted_items_count = ActiveRecord::Base.connection.send(:delete, sanitized_query)
+            deleted_items_count = Porpoise::KeyValueObject.connection.send(:delete, sanitized_query)
             total_deleted_items_count += deleted_items_count
           end
         end

--- a/lib/porpoise/version.rb
+++ b/lib/porpoise/version.rb
@@ -1,3 +1,3 @@
 module Porpoise
-  VERSION = "0.9.6"
+  VERSION = "0.9.7"
 end

--- a/spec/cache_spec.rb
+++ b/spec/cache_spec.rb
@@ -116,6 +116,13 @@ describe ActiveSupport::Cache::PorpoiseStore do
     expect(cache.read('foo_not_expiring_2')).to eql('bar_not_expiring_2')
   end
 
+  it 'uses the database connection of Porpoise::KeyValueObject when cleaning expired items' do
+    expect(Porpoise::KeyValueObject).to receive(:connection).and_call_original
+
+    cache = ActiveSupport::Cache::PorpoiseStore.new({ namespace: 'porpoise-test8' })
+    cache.cleanup
+  end
+
   it "can fetch an item from cache with a block and set an expiration date" do
     cache = ActiveSupport::Cache::PorpoiseStore.new({ namespace: 'porpoise-test9' })
     expect(cache.fetch('faz', expires_in: 1.hour) { 'baz' }).to eql('baz')


### PR DESCRIPTION
Use database connection of Porpoise::KeyValueObject when cleaning expired cache items.

This is a different database connection then that of ActiveRecord::Base as
Porpoise uses a different database for easy optimization and decoupling.

Update version to 0.9.7